### PR TITLE
Fix API

### DIFF
--- a/src/llmsearch/ranking.py
+++ b/src/llmsearch/ranking.py
@@ -82,7 +82,7 @@ def get_relevant_documents(
     llm_bundle,
     config: SemanticSearchConfig,
     label: str,
-    source_chunk_type: str, 
+    source_chunk_type: str = "", 
     offset_max_chars: int = 0
 ) -> Tuple[List[Document], float]:
     most_relevant_docs = []


### PR DESCRIPTION
Hello,

This fixes the following error when running with llmsearchapi. Thanks!

Error:
```
INFO:     172.25.112.1:63273 - "GET /semantic?question=hello HTTP/1.1" 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/home/guspuffy/anaconda3/envs/llmsearch-dev/lib/python3.11/site-packages/uvicorn/protocols/http/httptools_impl.py", line 409, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/guspuffy/anaconda3/envs/llmsearch-dev/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/guspuffy/anaconda3/envs/llmsearch-dev/lib/python3.11/site-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/home/guspuffy/anaconda3/envs/llmsearch-dev/lib/python3.11/site-packages/starlette/applications.py", line 122, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/home/guspuffy/anaconda3/envs/llmsearch-dev/lib/python3.11/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "/home/guspuffy/anaconda3/envs/llmsearch-dev/lib/python3.11/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/home/guspuffy/anaconda3/envs/llmsearch-dev/lib/python3.11/site-packages/starlette/middleware/cors.py", line 83, in __call__
    await self.app(scope, receive, send)
  File "/home/guspuffy/anaconda3/envs/llmsearch-dev/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/home/guspuffy/anaconda3/envs/llmsearch-dev/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/home/guspuffy/anaconda3/envs/llmsearch-dev/lib/python3.11/site-packages/starlette/routing.py", line 718, in __call__
    await route.handle(scope, receive, send)
  File "/home/guspuffy/anaconda3/envs/llmsearch-dev/lib/python3.11/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/home/guspuffy/anaconda3/envs/llmsearch-dev/lib/python3.11/site-packages/starlette/routing.py", line 66, in app
    response = await func(request)
               ^^^^^^^^^^^^^^^^^^^
  File "/home/guspuffy/anaconda3/envs/llmsearch-dev/lib/python3.11/site-packages/fastapi/routing.py", line 299, in app
    raise e
  File "/home/guspuffy/anaconda3/envs/llmsearch-dev/lib/python3.11/site-packages/fastapi/routing.py", line 294, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/guspuffy/anaconda3/envs/llmsearch-dev/lib/python3.11/site-packages/fastapi/routing.py", line 191, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/guspuffy/third-party/llm-search/src/llmsearch/api.py", line 105, in semanticsearch
    docs = get_relevant_documents(
           ^^^^^^^^^^^^^^^^^^^^^^^
TypeError: get_relevant_documents() missing 1 required positional argument: 'source_chunk_type'
```

After fix:
```
2025-01-11 11:25:30.864 | DEBUG    | llmsearch.ranking:get_relevant_documents:103 - Evaluating query: hello
2025-01-11 11:25:30.864 | INFO     | llmsearch.ranking:get_relevant_documents:105 - Adding query prefix for retrieval: query: 
2025-01-11 11:25:30.864 | INFO     | llmsearch.splade:query:248 - SPLADE search will search over all documents of chunk size: 1024. Number of docs: 0
2025-01-11 11:25:33.395 | INFO     | llmsearch.ranking:get_relevant_documents:111 - Stage 1: Got 0 documents.
2025-01-11 11:25:33.395 | INFO     | llmsearch.ranking:get_relevant_documents:133 - Dense embeddings filter: None
2025-01-11 11:25:33.586 | DEBUG    | llmsearch.ranking:get_relevant_documents:149 - NUMBER OF NEW DOCS to RETRIEVE: 25
2025-01-11 11:25:33.587 | INFO     | llmsearch.ranking:rerank:64 - Reranking documents ... 
2025-01-11 11:25:33.587 | INFO     | llmsearch.ranking:get_scores:40 - Reranking documents ... 
[-2.983222484588623, -7.157781600952148, -2.983222484588623, -2.983222484588623, -2.983222484588623, -8.368499755859375, -7.697229862213135, -8.093681335449219, -9.134628295898438, -8.490164756774902, -7.947393894195557, -7.554416656494141, -2.983222484588623, -2.983222484588623, -2.983222484588623, -2.983222484588623, -2.983222484588623, -4.7986955642700195, -2.983222484588623, -2.983222484588623, -2.983222484588623, -2.983222484588623, -9.799060821533203, -9.462366104125977, -6.877066612243652]
2025-01-11 11:25:38.478 | INFO     | llmsearch.ranking:rerank:72 - [-2.983222484588623, -2.983222484588623, -2.983222484588623, -2.983222484588623, -2.983222484588623, -2.983222484588623, -2.983222484588623, -2.983222484588623, -2.983222484588623, -2.983222484588623, -2.983222484588623, -2.983222484588623, -2.983222484588623, -4.7986955642700195, -6.877066612243652, -7.157781600952148, -7.554416656494141, -7.697229862213135, -7.947393894195557, -8.093681335449219, -8.368499755859375, -8.490164756774902, -9.134628295898438, -9.462366104125977, -9.799060821533203]
2025-01-11 11:25:38.478 | INFO     | llmsearch.ranking:get_relevant_documents:169 - New most relevant query: hello
2025-01-11 11:25:38.478 | INFO     | llmsearch.ranking:get_relevant_documents:176 - Number of documents after stage 2 (dense + sparse): 25
2025-01-11 11:25:38.478 | INFO     | llmsearch.ranking:get_relevant_documents:179 - Re-ranker avg. scores for top 5 resuls, chunk size 1024: -2.98
INFO:     172.25.112.1:63410 - "GET /semantic?question=hello HTTP/1.1" 200 OK
```